### PR TITLE
Fix docker-compose of Dev Node

### DIFF
--- a/docs/node-operator/dev-node.md
+++ b/docs/node-operator/dev-node.md
@@ -94,7 +94,7 @@ services:
       - ./elysium-testnet-data:/data
     command: [
       "--name", "elysium-dev-node",
-      "--dev"
+      "--dev",
       "--ws-external",
       "--rpc-external",
       "--rpc-cors", "all"


### PR DESCRIPTION
In docker-compose list of commands,   "--dev" parameter is missing "," in the end