### PR TITLE
Stable2407

### DIFF
--- a/docs/node-operator/dev-node.md
+++ b/docs/node-operator/dev-node.md
@@ -95,7 +95,6 @@ services:
     command: [
       "--name", "elysium-dev-node",
       "--dev",
-      "--ws-external",
       "--rpc-external",
       "--rpc-cors", "all"
     ]

--- a/docs/node-operator/dev-node.md
+++ b/docs/node-operator/dev-node.md
@@ -88,7 +88,7 @@ services:
     ports:
       - 30333:30333 # p2p port
       - 9933:9933 # rpc port
-      - 9944:9944 # ws port
+      - 9944:9933 # redirect all traffic of ws to rpc port
       - 9615:9615 # promethus port
     volumes:
       - ./elysium-testnet-data:/data

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` | Specifies the maximum number of WS RPC server connections.
+| `--ws-max-connections <count>` | Specifies the maximum number of WS RPC server.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,4 +255,4 @@ You can use the following options inside the docker-compose command.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
-As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards..
+As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards.

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -97,6 +97,7 @@ services:
     ports:
       - 30333:30333 # p2p port
       - 9933:9933 # rpc port
+      - 9944:9933 # ws/rpc port
       - 9615:9615 # promethus port
     volumes:
       - ~/elysium-data:/data

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,6 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `----`.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` | Specifies   .
+| `--ws-max-connections <count>` |    .
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -196,7 +196,7 @@ You can use the following optional flags inside the docker-compose command.
 | `--two` | Provides a shortcut for specifying `--name Two --validator` to add session keys for `Two` to the keystore.
 | `--unsafe-pruning` | Forces the node to start with unsafe pruning settings. When running as a validator, it is highly recommended to disable state pruning (that is, archive) which is the default. The node will refuse to start as a validator if pruning is enabled unless this option is set.
 | `--unsafe-rpc-external` | Listens to all RPC interfaces. This option is the same as `--rpc-external`.
-| `--unsafe-ws-external` | Listens to
+| `--unsafe-ws-external` | 
 | `--validator` | Starts the node with the authority role and enables it to actively participate in any consensus task that it can (for example, depending on availability of local keys).
 | `-V`, `--version` | Displays version information.
 | `--ws-external` | Listens to all Websocket interfaces. By default, the node only listens locally. Keep in mind that not all RPC methods are safe to be exposed publicly. You can use an RPC proxy server to filter out dangerous methods. You can use `--unsafe-ws-external` to suppress the warning if you understand the risks.

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` | Specifies the maximum number.
+| `--ws-max-connections <count>` | Specifies the maximum .
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -105,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--rpc-max-connections=number of connectio"
+      "--rpc-max-connections=number of connection"
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,4 +255,4 @@ You can use the following options inside the docker-compose command.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
-As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards.
+As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards..

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` | Specifies the maximum number of.
+| `--ws-max-connections <count>` | Specifies the maximum number.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -105,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--rpc-max-connections=number of con"
+      "--rpc-max-connections=number of conn"
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` | Specifies the  .
+| `--ws-max-connections <count>` | Specifies   .
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -97,7 +97,6 @@ services:
     ports:
       - 30333:30333 # p2p port
       - 9933:9933 # rpc port
-      - 9944:9944 # ws port
       - 9615:9615 # promethus port
     volumes:
       - ~/elysium-data:/data
@@ -106,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--unsafe-ws-external",
+      "--rpc-max-connections="
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` | Specifies the maximum number of WS.
+| `--ws-max-connections <count>` | Specifies the maximum number of.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -196,7 +196,7 @@ You can use the following optional flags inside the docker-compose command.
 | `--two` | Provides a shortcut for specifying `--name Two --validator` to add session keys for `Two` to the keystore.
 | `--unsafe-pruning` | Forces the node to start with unsafe pruning settings. When running as a validator, it is highly recommended to disable state pruning (that is, archive) which is the default. The node will refuse to start as a validator if pruning is enabled unless this option is set.
 | `--unsafe-rpc-external` | Listens to all RPC interfaces. This option is the same as `--rpc-external`.
-| `--unsafe-ws-external` | Listens to all Websocket interfaces. This option is the same as `--ws-external` but doesn't warn you about it.
+| `--unsafe-ws-external` | Listens to all Websocket interfaces. This option is the same as `--ws-external` but doesn't warn you about.
 | `--validator` | Starts the node with the authority role and enables it to actively participate in any consensus task that it can (for example, depending on availability of local keys).
 | `-V`, `--version` | Displays version information.
 | `--ws-external` | Listens to all Websocket interfaces. By default, the node only listens locally. Keep in mind that not all RPC methods are safe to be exposed publicly. You can use an RPC proxy server to filter out dangerous methods. You can use `--unsafe-ws-external` to suppress the warning if you understand the risks.

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` | Specifies the maximum number of WS RPC .
+| `--ws-max-connections <count>` | Specifies the maximum number of WS.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -105,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--rpc-max-connections=number of connect"
+      "--rpc-max-connections=number of connecti"
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -105,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--rpc-max-connections="
+      "--rpc-max-connections=number"
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -105,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--rpc-max-connections=number of connecti"
+      "--rpc-max-connections=number of connectio"
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -196,7 +196,7 @@ You can use the following optional flags inside the docker-compose command.
 | `--two` | Provides a shortcut for specifying `--name Two --validator` to add session keys for `Two` to the keystore.
 | `--unsafe-pruning` | Forces the node to start with unsafe pruning settings. When running as a validator, it is highly recommended to disable state pruning (that is, archive) which is the default. The node will refuse to start as a validator if pruning is enabled unless this option is set.
 | `--unsafe-rpc-external` | Listens to all RPC interfaces. This option is the same as `--rpc-external`.
-| `--unsafe-ws-external` | Listens to all Websocket interfaces. This option is the same as `--ws-external` but doesn't warn you about.
+| `--unsafe-ws-external` | Listens to all Websocket interfaces. This option is the same as `--ws-external` but doesn't warn.
 | `--validator` | Starts the node with the authority role and enables it to actively participate in any consensus task that it can (for example, depending on availability of local keys).
 | `-V`, `--version` | Displays version information.
 | `--ws-external` | Listens to all Websocket interfaces. By default, the node only listens locally. Keep in mind that not all RPC methods are safe to be exposed publicly. You can use an RPC proxy server to filter out dangerous methods. You can use `--unsafe-ws-external` to suppress the warning if you understand the risks.

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -196,7 +196,6 @@ You can use the following optional flags inside the docker-compose command.
 | `--two` | Provides a shortcut for specifying `--name Two --validator` to add session keys for `Two` to the keystore.
 | `--unsafe-pruning` | Forces the node to start with unsafe pruning settings. When running as a validator, it is highly recommended to disable state pruning (that is, archive) which is the default. The node will refuse to start as a validator if pruning is enabled unless this option is set.
 | `--unsafe-rpc-external` | Listens to all RPC interfaces. This option is the same as `--rpc-external`.
-| `--unsafe-ws-external` | 
 | `--validator` | Starts the node with the authority role and enables it to actively participate in any consensus task that it can (for example, depending on availability of local keys).
 | `-V`, `--version` | Displays version information.
 | `--ws-external` | Listens to all Websocket interfaces. By default, the node only listens locally. Keep in mind that not all RPC methods are safe to be exposed publicly. You can use an RPC proxy server to filter out dangerous methods. You can use `--unsafe-ws-external` to suppress the warning if you understand the risks.

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` | Specifies the maximum number of WS RPC server.
+| `--ws-max-connections <count>` | Specifies the maximum number of WS RPC .
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -105,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--rpc-max-connections=number of"
+      "--rpc-max-connections=number of con"
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -105,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--rpc-max-connections=number of conn"
+      "--rpc-max-connections=number of connec"
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -196,7 +196,7 @@ You can use the following optional flags inside the docker-compose command.
 | `--two` | Provides a shortcut for specifying `--name Two --validator` to add session keys for `Two` to the keystore.
 | `--unsafe-pruning` | Forces the node to start with unsafe pruning settings. When running as a validator, it is highly recommended to disable state pruning (that is, archive) which is the default. The node will refuse to start as a validator if pruning is enabled unless this option is set.
 | `--unsafe-rpc-external` | Listens to all RPC interfaces. This option is the same as `--rpc-external`.
-| `--unsafe-ws-external` | Listens to all Websocket interfaces. This option is the same as `--ws-external`.
+| `--unsafe-ws-external` | Listens to all Websocket interfaces. This option is the same as.
 | `--validator` | Starts the node with the authority role and enables it to actively participate in any consensus task that it can (for example, depending on availability of local keys).
 | `-V`, `--version` | Displays version information.
 | `--ws-external` | Listens to all Websocket interfaces. By default, the node only listens locally. Keep in mind that not all RPC methods are safe to be exposed publicly. You can use an RPC proxy server to filter out dangerous methods. You can use `--unsafe-ws-external` to suppress the warning if you understand the risks.

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -198,7 +198,6 @@ You can use the following optional flags inside the docker-compose command.
 | `--unsafe-rpc-external` | Listens to all RPC interfaces. This option is the same as `--rpc-external`.
 | `--validator` | Starts the node with the authority role and enables it to actively participate in any consensus task that it can (for example, depending on availability of local keys).
 | `-V`, `--version` | Displays version information.
-| `--ws-external` | Listens to all Websocket interfaces. By default, the node only listens locally. Keep in mind that not all RPC methods are safe to be exposed publicly. You can use an RPC proxy server to filter out dangerous methods. You can use `--unsafe-ws-external` to suppress the warning if you understand the risks.
 
 ### Options
 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -105,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--rpc-max-connections=number of connec"
+      "--rpc-max-connections=number of connect"
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -196,7 +196,7 @@ You can use the following optional flags inside the docker-compose command.
 | `--two` | Provides a shortcut for specifying `--name Two --validator` to add session keys for `Two` to the keystore.
 | `--unsafe-pruning` | Forces the node to start with unsafe pruning settings. When running as a validator, it is highly recommended to disable state pruning (that is, archive) which is the default. The node will refuse to start as a validator if pruning is enabled unless this option is set.
 | `--unsafe-rpc-external` | Listens to all RPC interfaces. This option is the same as `--rpc-external`.
-| `--unsafe-ws-external` | Listens to all Websocket interfaces. This option is the same as.
+| `--unsafe-ws-external` | Listens to
 | `--validator` | Starts the node with the authority role and enables it to actively participate in any consensus task that it can (for example, depending on availability of local keys).
 | `-V`, `--version` | Displays version information.
 | `--ws-external` | Listens to all Websocket interfaces. By default, the node only listens locally. Keep in mind that not all RPC methods are safe to be exposed publicly. You can use an RPC proxy server to filter out dangerous methods. You can use `--unsafe-ws-external` to suppress the warning if you understand the risks.

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` |    .
+| `--ws-max-connections <count>` .
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -105,7 +105,7 @@ services:
       "--rpc-cors", "all",
       "--unsafe-rpc-external",
       "--rpc-methods=unsafe",
-      "--rpc-max-connections=number"
+      "--rpc-max-connections=number of"
       "--prometheus-external",
       "--node-key", "your node key from subkey",
       "--chain", "/usr/local/bin/elysiumSpecRaw.json",

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` | Specifies the maximum .
+| `--ws-max-connections <count>` | Specifies the  .
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,4 +255,4 @@ You can use the following options inside the docker-compose command.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
-As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 
+As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards.

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws--`.
+| `----`.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-`.
+| `--ws--`.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections`.
+| `--ws-max-`.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>` .
+| `--ws-max-connections <count>`.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -255,7 +255,7 @@ You can use the following options inside the docker-compose command.
 | `--tracing-targets <targets>` | Sets a custom profiling filter. The syntax is the same as for logging: `<target>=<level>`.
 | `--wasm-execution <method>` | Specifies the method for executing Wasm runtime code. Valid values are `interpreted`, or `compiled`. The default is `Compiled`.
 | `--wasm-runtime-overrides <path>` | Specifies the path where local WASM runtimes are stored. These runtimes override on-chain runtimes when the version matches.
-| `--ws-max-connections <count>`.
+| `--ws-max-connections`.
 | `--rpc-port <port>` | Specifies the TCP port to use for the WebSockets RPC server.
 
 As Elysium is a private chain, you need to contact with Elysium team to allow your Node's PeerID to participate as a validator and earn rewards. 

--- a/docs/node-operator/validator-node.md
+++ b/docs/node-operator/validator-node.md
@@ -196,7 +196,7 @@ You can use the following optional flags inside the docker-compose command.
 | `--two` | Provides a shortcut for specifying `--name Two --validator` to add session keys for `Two` to the keystore.
 | `--unsafe-pruning` | Forces the node to start with unsafe pruning settings. When running as a validator, it is highly recommended to disable state pruning (that is, archive) which is the default. The node will refuse to start as a validator if pruning is enabled unless this option is set.
 | `--unsafe-rpc-external` | Listens to all RPC interfaces. This option is the same as `--rpc-external`.
-| `--unsafe-ws-external` | Listens to all Websocket interfaces. This option is the same as `--ws-external` but doesn't warn.
+| `--unsafe-ws-external` | Listens to all Websocket interfaces. This option is the same as `--ws-external`.
 | `--validator` | Starts the node with the authority role and enables it to actively participate in any consensus task that it can (for example, depending on availability of local keys).
 | `-V`, `--version` | Displays version information.
 | `--ws-external` | Listens to all Websocket interfaces. By default, the node only listens locally. Keep in mind that not all RPC methods are safe to be exposed publicly. You can use an RPC proxy server to filter out dangerous methods. You can use `--unsafe-ws-external` to suppress the warning if you understand the risks.


### PR DESCRIPTION
**Changes in the New Release:**

**Traffic Routing:**
   All traffic will now be routed through the RPC node.
   
**Max Runtime Instances:**
   If you're using the --max-runtime-instances flag, set its value to maximum 32.
   
**Deprecated Flags:**
  Remove the following flags from your configuration:
 `--ws-max-connections`
 `--ws-port`
 `--unsafe-ws-external`
 
  This should guide you in adjusting your settings for the new release. Let me know if you need further clarification!_
